### PR TITLE
Ensures the proper dynamically constructed Apache mirror download is …

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -34,7 +34,7 @@ export async function getMaven(version: string) {
 async function downloadMaven(version: string): Promise<string> {
   const toolDirectoryName = `apache-maven-${version}`
   const downloadUrl =
-    `https://archive.apache.org/dist/maven/maven-3/${version}/binaries/${toolDirectoryName}-bin.tar.gz`
+    `https://apache.org/dyn/closer.cgi?filename=maven/maven-3/${version}/binaries/${toolDirectoryName}-bin.tar.gz&action=download`
   console.log(`downloading ${downloadUrl}`)
 
   try {


### PR DESCRIPTION
ASF infrastructure doesn't want downlaods direct from the archive.  Instead you should use download mirrors.  This is best done using a dynamically constructed mirror URL.  This code change moves to this approach which will ensure we distribute download to appropriate global servers and doesn't get us blocked by ASF infra.