### PR TITLE
Update maven to latest version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'stCarolas'
 inputs:
   maven-version:
     description: 'Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0'
-    default: '3.5.4'
+    default: '3.8.2'
 runs:
   using: 'node12'
   main: 'lib/setup-maven.js'


### PR DESCRIPTION
Update to latest version.
I think it is convinient to keep latest version in use.

Our usecase is that we have 50 WF files, and if we set `maven-version` in each of them we will trigger 50 jobs, which will cause a lot of unnecessary noise and performance impact.

If we have latest version defined in action itself, then we dont have to change WF files and trigger jobs.

Also,  I think it would be convenient that lates version is called `latest` and that one is set by default, so action users do not have to remember to upgrade.

Thanks